### PR TITLE
Error in Block with stride>2

### DIFF
--- a/networks/deeplab_xception.py
+++ b/networks/deeplab_xception.py
@@ -78,7 +78,7 @@ class Block(nn.Module):
             rep = rep[1:]
 
         if stride != 1:
-            rep.append(SeparableConv2d_same(planes, planes, 3, stride=2))
+            rep.append(SeparableConv2d_same(planes, planes, 3, stride=stride))
 
         self.rep = nn.Sequential(*rep)
 


### PR DESCRIPTION
The current implementation of the block leeds to an error in the forward pass if stride>2. This commit change the hard coded wrong 2 with the correct variable stride. Now the forward pass of the block works with stride>2