### PR TITLE
Bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Fellow steps below to train your model:
     ```Shell
     usage: train.py [-h] [--backbone {resnet,xception,drn,mobilenet}]
                 [--out-stride OUT_STRIDE] [--dataset {pascal,coco,cityscapes}]
-                [--use-sbd] [--workers N] [--base-size BASE_SIZE]
+                [--dont-use-sbd] [--workers N] [--base-size BASE_SIZE]
                 [--crop-size CROP_SIZE] [--sync-bn SYNC_BN]
                 [--freeze-bn FREEZE_BN] [--loss-type {ce,focal}] [--epochs N]
                 [--start_epoch N] [--batch-size N] [--test-batch-size N]

--- a/dataloaders/__init__.py
+++ b/dataloaders/__init__.py
@@ -6,7 +6,7 @@ def make_data_loader(args, **kwargs):
     if args.dataset == 'pascal':
         train_set = pascal.VOCSegmentation(args, split='train')
         val_set = pascal.VOCSegmentation(args, split='val')
-        if args.use_sbd:
+        if not args.dont_use_sbd:
             sbd_train = sbd.SBDSegmentation(args, split=['train', 'val'])
             train_set = combine_dbs.CombineDBs([train_set, sbd_train], excluded=[val_set])
 

--- a/train.py
+++ b/train.py
@@ -185,8 +185,8 @@ def main():
     parser.add_argument('--dataset', type=str, default='pascal',
                         choices=['pascal', 'coco', 'cityscapes'],
                         help='dataset name (default: pascal)')
-    parser.add_argument('--use-sbd', action='store_true', default=True,
-                        help='whether to use SBD dataset (default: True)')
+    parser.add_argument('--dont-use-sbd', action='store_true',
+                        help='whether to not use SBD dataset (default: use SBD)')
     parser.add_argument('--workers', type=int, default=4,
                         metavar='N', help='dataloader threads')
     parser.add_argument('--base-size', type=int, default=513,

--- a/train_voc.sh
+++ b/train_voc.sh
@@ -1,1 +1,1 @@
-CUDA_VISIBLE_DEVICES=0,1,2,3 python train.py --backbone resnet --lr 0.007 --workers 4 --use-sbd True --epochs 50 --batch-size 16 --gpu-ids 0,1,2,3 --checkname deeplab-resnet --eval-interval 1 --dataset pascal
+CUDA_VISIBLE_DEVICES=0,1,2,3 python train.py --backbone resnet --lr 0.007 --workers 4 --epochs 50 --batch-size 16 --gpu-ids 0,1,2,3 --checkname deeplab-resnet --eval-interval 1 --dataset pascal

--- a/utils/loss.py
+++ b/utils/loss.py
@@ -2,11 +2,10 @@ import torch
 import torch.nn as nn
 
 class SegmentationLosses(object):
-    def __init__(self, weight=None, size_average=True, batch_average=True, ignore_index=255, cuda=False):
+    def __init__(self, weight=None, reduction="mean", ignore_index=255, cuda=False):
         self.ignore_index = ignore_index
         self.weight = weight
-        self.size_average = size_average
-        self.batch_average = batch_average
+        self.reduction = reduction
         self.cuda = cuda
 
     def build_loss(self, mode='ce'):
@@ -21,21 +20,18 @@ class SegmentationLosses(object):
     def CrossEntropyLoss(self, logit, target):
         n, c, h, w = logit.size()
         criterion = nn.CrossEntropyLoss(weight=self.weight, ignore_index=self.ignore_index,
-                                        size_average=self.size_average)
+                                        reduction=self.reduction)
         if self.cuda:
             criterion = criterion.cuda()
 
         loss = criterion(logit, target.long())
-
-        if self.batch_average:
-            loss /= n
 
         return loss
 
     def FocalLoss(self, logit, target, gamma=2, alpha=0.5):
         n, c, h, w = logit.size()
         criterion = nn.CrossEntropyLoss(weight=self.weight, ignore_index=self.ignore_index,
-                                        size_average=self.size_average)
+                                        reduction=self.reduction)
         if self.cuda:
             criterion = criterion.cuda()
 
@@ -44,9 +40,6 @@ class SegmentationLosses(object):
         if alpha is not None:
             logpt *= alpha
         loss = -((1 - pt) ** gamma) * logpt
-
-        if self.batch_average:
-            loss /= n
 
         return loss
 


### PR DESCRIPTION
Your sbd flag always evaluated to `True`, because the `action='store_true', default=True` will be true when the flag is not present by default and then true when the flag is present via the action.  To keep the default as using sbd, I needed to change the flag name.  If you prefer your flag name, then the default will be false, because logically if the `--use-sbd` flag is present then we use the dataset and if it's not then we don't use it.

I also fixed the loss function.  The `size_average` parameter is now deprecated.  Additionally as stated in #55, the loss is already averaged over the batch so you shouldn't average it again over the batch size.