### PR TITLE
solve the saving-folder bug

### DIFF
--- a/utils/saver.py
+++ b/utils/saver.py
@@ -9,9 +9,9 @@ class Saver(object):
     def __init__(self, args):
         self.args = args
         self.directory = os.path.join('run', args.dataset, args.checkname)
-        self.runs = sorted(glob.glob(os.path.join(self.directory, 'experiment_*')))
-        run_id = int(self.runs[-1].split('_')[-1]) + 1 if self.runs else 0
-
+        self.runs = glob.glob(os.path.join(self.directory, 'experiment_*'))
+        run_id = sorted(int(run.split('_')[-1]) for run in self.runs)[-1] + 1 if self.runs else 0
+            
         self.experiment_dir = os.path.join(self.directory, 'experiment_{}'.format(str(run_id)))
         if not os.path.exists(self.experiment_dir):
             os.makedirs(self.experiment_dir)


### PR DESCRIPTION
The previous code has the problem that the number of saving folders, "experiment_*", will not increase beyond 10. This is due to the sorted function on strs, which is not the same as sort of integers. For example, the result of sorted(["11", "2", "1","3"]) will be ["1", "11", "2","3"], but what we want is ["1","2","3","11"]